### PR TITLE
PoC: Build the package virtualenv using uv

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -51,6 +51,12 @@ RUN  --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs
 
+# Install uv for faster Python package installation
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+
+# Install uv-pip wrapper for dh-virtualenv's --pip-tool
+COPY uv-pip /usr/local/bin/uv-pip
+
 RUN  chmod 777 /home
 ENV  HOME=/home
 ENV  QUILT_PATCHES=debian/patches

--- a/debian/patches/add-python-gammu-dependency
+++ b/debian/patches/add-python-gammu-dependency
@@ -1,5 +1,10 @@
---- nav-debian.orig/requirements/optional.txt
-+++ nav-debian/requirements/optional.txt
-@@ -1 +1,2 @@
- python-ldap==3.4.5 # optional for LDAP authentication, requires libldap (OpenLDAP) to build
-+python-gammu==3.2.4
+--- nav-debian.orig/pyproject.toml
++++ nav-debian/pyproject.toml
+@@ -66,6 +66,7 @@
+ [project.optional-dependencies]
+ ldap = ["python-ldap==3.4.5"]  # optional for LDAP authentication, requires libldap (OpenLDAP) to build
+ docs = ["sphinx_rtd_theme>=2.0.0"]
++gammu = ["python-gammu==3.2.4"]
+
+ [dependency-groups]
+ dev = [

--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,11 @@ override_dh_virtualenv:
 
 	dh_virtualenv --pip-tool /usr/local/bin/uv-pip --extras docs,ldap,gammu --extra-pip-arg="-cconstraints.txt" --extra-pip-arg "setuptools>=50.2.0"
 
+	# Replace Debian's patched pip (which requires system python3-pip) with upstream pip
+	/usr/local/bin/uv pip install --reinstall --python $(DEBIAN_ROOT)/opt/venvs/nav/bin/python pip
+	# Fix shebangs: uv writes the build-time path, but dh-virtualenv expects /opt/venvs/nav/...
+	sed -i '1s|#!$(DEBIAN_ROOT)/opt/venvs/nav/|#!/opt/venvs/nav/|' $(DEBIAN_ROOT)/opt/venvs/nav/bin/pip*
+
 	$(DEBIAN_ROOT)/opt/venvs/nav/bin/python $(DEBIAN_ROOT)/opt/venvs/nav/bin/sphinx-build doc/ doc/_build/html
 	dh_installdocs doc/_build/html
 	dh_installdocs NOTES.rst

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ override_dh_virtualenv:
 	npm install
 	npm run build:sass
 
-	dh_virtualenv --pip-tool /usr/local/bin/uv-pip --extra-pip-arg "-rdoc/requirements.txt" --extra-pip-arg="-cconstraints.txt" --extra-pip-arg "setuptools>=50.2.0"
+	dh_virtualenv --pip-tool /usr/local/bin/uv-pip --extras docs,ldap,gammu --extra-pip-arg="-cconstraints.txt" --extra-pip-arg "setuptools>=50.2.0"
 
 	$(DEBIAN_ROOT)/opt/venvs/nav/bin/python $(DEBIAN_ROOT)/opt/venvs/nav/bin/sphinx-build doc/ doc/_build/html
 	dh_installdocs doc/_build/html

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ override_dh_virtualenv:
 	npm install
 	npm run build:sass
 
-	dh_virtualenv --extra-pip-arg "-rdoc/requirements.txt" --extra-pip-arg="-cconstraints.txt" --extra-pip-arg "setuptools>=50.2.0"
+	dh_virtualenv --pip-tool /usr/local/bin/uv-pip --extra-pip-arg "-rdoc/requirements.txt" --extra-pip-arg="-cconstraints.txt" --extra-pip-arg "setuptools>=50.2.0"
 
 	$(DEBIAN_ROOT)/opt/venvs/nav/bin/python $(DEBIAN_ROOT)/opt/venvs/nav/bin/sphinx-build doc/ doc/_build/html
 	dh_installdocs doc/_build/html

--- a/debian/uv-pip
+++ b/debian/uv-pip
@@ -1,0 +1,17 @@
+"""dh-virtualenv pip-tool wrapper that delegates to uv pip.
+
+dh-virtualenv invokes the pip-tool as:
+    <venv>/bin/python <pip-tool> install [args...]
+
+This wrapper sets VIRTUAL_ENV so uv knows which environment to target,
+then execs into `uv pip` with the original arguments.
+"""
+import os
+import sys
+
+os.environ["VIRTUAL_ENV"] = sys.prefix
+
+# Filter out args unsupported by uv pip (e.g. --log added by dh-virtualenv)
+args = [a for a in sys.argv[1:] if not a.startswith("--log")]
+
+os.execv("/usr/local/bin/uv", ["uv", "pip"] + args + ["--link-mode", "copy"])


### PR DESCRIPTION
## Scope and purpose

This speeds up the package build enormously, by forcing dh_virtualenv to use `uv pip` instead of plain `pip`.

Package building works, but the resulting packages should be tested more before we release them, so keeping this in draft.


